### PR TITLE
Dev

### DIFF
--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -150,8 +150,8 @@ endfunction
 function! tests#vl#Benchmark() abort
     let e = "(begin (define double (lambda (x) (+ x x)) (double (double (double 7)))))"
     let Func = {-> vl#Eval(e)}
-    call s:Benchmark("nested double function call", Func, 100)
+    call s:Benchmark("nested double function call", Func, 200)
     let e = '(let ((x 0) (y 0)) (while ((< (+ x y) 100)) (set! x (+ x 1)) (set! y (+ y 1))) y)'
     let Func = {-> vl#Eval(e)}
-    call s:Benchmark("while loop 50 reps", Func, 100)
+    call s:Benchmark("while loop 50 reps", Func, 200)
 endfunction

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -23,7 +23,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
-                echo "[+] "..string(expr)
+                "echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr
@@ -35,6 +35,7 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[["condition", [123, []]], '(raise 123)'],
                 \[[1, [2, []]], "'(1 . (2 . ()))"],
                 \[[1, []], "'(1 . ())"],
                 \[[], "'()"],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -23,7 +23,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
-                "echo "[+] "..string(expr)
+                echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr
@@ -35,16 +35,16 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[[1, [2, []]], "'(1 . (2 . ()))"],
+                \[[1, []], "'(1 . ())"],
+                \[[], "'()"],
+                \[-3, '-3'],
+                \[123, 123],
+                \[3, 'x'],
                 \[3, '(+ 1 (+ 1 1))'],
                 \[3, '(- 5 2)'],
                 \[10, '(* 5 2)'],
                 \[3, '(/ 12 4)'],
-                \[[1, [2, []]], "'(1 . (2 . ()))"],
-                \[[1, []], "'(1 . ())"],
-                \[[], "'()"],
-                \[3, 'x'],
-                \[-3, '-3'],
-                \[123, 123],
                 \[0, "(define x 3)"],
                 \[0, '(define x "hello, world")'],
                 \[0, '(set! x 3)'],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -41,17 +41,17 @@ function! tests#vl#TestVimLisp() abort
                 \[-3, '-3'],
                 \[123, 123],
                 \[3, 'x'],
-                \[3, '(+ 1 (+ 1 1))'],
                 \[3, '(- 5 2)'],
+                \[3, '(+ 1 (+ 1 1))'],
                 \[10, '(* 5 2)'],
                 \[3, '(/ 12 4)'],
+                \[3, '(+ 1 2)'],
                 \[0, "(define x 3)"],
+                \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[0, '(define x "hello, world")'],
                 \[0, '(set! x 3)'],
                 \[4, '(begin 1 2 4)'],
                 \[3, '(begin (define x 3) x)'],
-                \[3, '(+ 1 2)'],
-                \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[7, '(call/cc (lambda (k) 7))'],
                 \[7, '(call/cc (lambda (k) (k 7)))'],
                 \[9, '((lambda () 5 7 9))'],
@@ -74,6 +74,9 @@ function! tests#vl#TestVimLisp() abort
                 \["x", "((lambda () 'x))"],
                 \[[1, [2, [3, []]]], "(cons 1 '(2 3))"],
                 \[[1, [2, [3, []]]], "(cons 1 (quote (2 3)))"],
+                \['#t', '(and)'],
+                \['#t', '(and (and 1 2 (and 3) (and) #t) #t)'],
+                \['#f', '(and (and 1 2 (and #f) (and) #t) #t)'],
                 \['#t', '(and (> 5 3))'],
                 \['#f', '(and (> 5 3) (> 1 3))'],
                 \['#f', '(and (> 1 3))'],
@@ -96,10 +99,10 @@ function! tests#vl#TestVimLisp() abort
                 \['#t', "(begin (define l '(1 2)) (eq? l l))"],
                 \[[1, 2], "'(1 . 2)"],
                 \[[1, [2, [3, []]]], "'(1 . (2 3))"],
-                \[5, '(let ((x 0)) (while ((< x 5)) (set! x (+ x 1))) x)'],
-                \[50, '(let ((x 0) (y 0)) (while ((< (+ x y) 100)) (set! x (+ x 1)) (set! y (+ y 1))) y)'],
-                \[6, '(begin (+ 3 3))'],
                 \])
+                "\[5, '(let ((x 0)) (while ((< x 5)) (set! x (+ x 1))) x)'],
+                "\[0, '(let ((x 0) (y 0)) (while ((< x 5)) (set! x (+ x 1))) y)'],
+                "\[50, '(let ((x 0) (y 0)) (while ((< (+ x y) 100)) (set! x (+ x 1)) (set! y (+ y 1))) y)'],
 
     call RunTests([
                 \["hello, world", vlutils#PrettyPrint(vl#Eval('"hello, world"'))],
@@ -148,10 +151,13 @@ function! s:Benchmark(desc, func, n) abort
 endfunction
 
 function! tests#vl#Benchmark() abort
-    let e = "(begin (define double (lambda (x) (+ x x)) (double (double (double 7)))))"
-    let Func = {-> vl#Eval(e)}
-    call s:Benchmark("nested double function call", Func, 200)
-    let e = '(let ((x 0) (y 0)) (while ((< (+ x y) 100)) (set! x (+ x 1)) (set! y (+ y 1))) y)'
+"    let e = "(begin (define double (lambda (x) (+ x x)) (double (double (double 7)))))"
+"    let Func = {-> vl#Eval(e)}
+"    call s:Benchmark("nested double function call", Func, 200)
+"    let e = '(let ((x 0) (y 0)) (while ((< (+ x y) 100)) (set! x (+ x 1)) (set! y (+ y 1))) y)'
+"    let Func = {-> vl#Eval(e)}
+"    call s:Benchmark("while loop 50 reps", Func, 200)
+    let e = "(begin (define ! (lambda (n) (if (equal? n 0) 1 (* n (! (- n 1)))))) (! 10))"
     let Func = {-> vl#Eval(e)}
     call s:Benchmark("while loop 50 reps", Func, 200)
 endfunction

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -23,6 +23,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
+                echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr
@@ -34,6 +35,7 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[3, '(+ 1 (+ 1 1))'],
                 \[3, '(- 5 2)'],
                 \[10, '(* 5 2)'],
                 \[3, '(/ 12 4)'],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -23,7 +23,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
-                echo "[+] "..string(expr)
+                "echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -63,10 +63,6 @@ function! s:Trampoline(bounce) abort
     endif
 endfunction
 
-function! s:ApplyCont(cont, val) abort
-    return a:cont(a:val)
-endfunction
-
 function! s:ApplyK() abort
     return s:PopK()(s:PopKVal())
 endfunction
@@ -377,7 +373,13 @@ endfunction
 
 function! s:ApplyProc(rator, rands, k) abort
     if vl#Car(a:rator) =~? '^prim$'
-        return {-> s:ApplyCont(a:k, vl#Cdr(a:rator)(a:rands))}
+        let fname = "PrimitiveApply"..s:COUNTER
+        function! {fname}() closure abort
+            call s:PushK(a:k)
+            call s:PushKVal(vl#Cdr(a:rator)(a:rands))
+            return s:ApplyK()
+        endfunction
+        return funcref(fname)
     elseif vl#Car(a:rator) =~? '^cont-prim$'
         return {-> vl#Cdr(a:rator)(vl#Car(a:rands))}
     elseif vl#Car(a:rator) =~? '^proc$'

--- a/autoload/vlbuiltins.vim
+++ b/autoload/vlbuiltins.vim
@@ -7,6 +7,13 @@ let s:lt = {x, y -> x < y ? g:vl_bool_t : g:vl_bool_f}
 let s:gte = {x, y -> x >= y ? g:vl_bool_t : g:vl_bool_f}
 let s:lte = {x, y -> x <= y ? g:vl_bool_t : g:vl_bool_f}
 
+function! s:PrettyPrintErr(err) abort
+    return vlutils#PrettyPrint(vl#Cdr(a:err))
+endfunction
+
+let s:ERR_OPS = {
+            \}
+
 let s:PAIR_OPS = {
             \'to_str': funcref("vlutils#PrintPair"),
             \}
@@ -57,6 +64,7 @@ let s:BUILTINS = {
             \g:vl_t_void: s:UNTYPED_OPS,
             \g:vl_t_pair: s:PAIR_OPS,
             \g:vl_t_sym: s:SYM_OPS,
+            \g:vl_t_err: s:ERR_OPS,
             \}
 
 function! vlbuiltins#ApplyGeneric(op, args) abort

--- a/autoload/vlparse.vim
+++ b/autoload/vlparse.vim
@@ -157,3 +157,35 @@ function! s:DeepLispList(elts) abort
         return vl#Cons(a:elts[0], s:DeepLispList(a:elts[1:]))
     endif
 endfunction
+
+function! vlparse#SplitExprs(source) abort
+    let remaining = a:source
+    let exprs = []
+    while len(remaining) > 0
+        if remaining[0] =~ '\s'
+            let remaining = remaining[1:]
+            continue
+        endif
+        let exprlen = vlparse#ExprLen(remaining)
+        let nextexpr = remaining[:exprlen-1]
+        call add(exprs, nextexpr)
+        let remaining = remaining[exprlen:]
+    endwhile
+    return exprs
+endfunction
+
+function! vlparse#ExprLen(tokens) abort
+    let first = a:tokens[0]
+    if first == s:L_PAREN
+        return s:NestedNonTerminalLen(a:tokens)
+    elseif first == s:D_QUOTE
+        return s:NonTerminalLen(a:tokens)
+    elseif first == s:QUOTE
+        if a:tokens[1] == s:L_PAREN
+            return 1 + s:NestedNonTerminalLen(a:tokens[1:])
+        endif
+        return 2
+    else
+        return 1
+    endif
+endfunction

--- a/autoload/vlparse.vim
+++ b/autoload/vlparse.vim
@@ -1,0 +1,159 @@
+let s:TOKEN_R = '\([()"'']\)'
+let s:PREV_FRAME_KEY = "__prev_frame"
+let s:SYMBOL_R = '^[a-zA-Z0-9?!*^/\\><=+_-]\+$'
+let s:STRING_CONST_R = '^".*"$'
+let s:NUMBER_R = '^-\?\d\+$'
+let s:BOOL_R = '^\(#t\)\|\(#f\)$'
+let s:R_PAREN = ")"
+let s:L_PAREN = "("
+let s:D_QUOTE = '"'
+let s:BACKTICK = "`"
+let s:QUOTE = "'"
+let s:DOT = "."
+
+
+function! vlparse#Tokenize(expr) abort
+    return split(substitute(a:expr, s:TOKEN_R, ' \1 ', 'g'))
+endfunction
+
+function! vlparse#Parse(tokens) abort
+    if len(a:tokens) == 0
+        throw "unterminated expression"
+    elseif a:tokens[0] == s:QUOTE
+        return vl#LispList(["quote", s:ParseQuoted(a:tokens[1:])])
+    elseif index(a:tokens, s:DOT) > -1
+        throw "invalid syntax"
+    elseif len(a:tokens) == 1
+        return s:ParseAtom(a:tokens[0])
+    elseif a:tokens[0] == s:L_PAREN
+        return vl#LispList(s:ParseList(a:tokens))
+    elseif a:tokens[0] == s:D_QUOTE
+        return vl#LispList(s:ParseString(a:tokens))
+    endif
+endfunction
+
+function! s:ParseQuoted(tokens) abort
+    if a:tokens[0] == s:L_PAREN && index(a:tokens, s:DOT) > 0
+        return s:ParsePair(a:tokens)
+    else
+        return vlparse#Parse(a:tokens)
+    endif
+endfunction
+
+function! s:ParseList(tokens) abort
+    if a:tokens[0] != s:L_PAREN || a:tokens[-1] != s:R_PAREN
+        throw "Invalid list structure -- s:ParseList"
+    endif
+    let tokens = a:tokens[1:-2]  " remove outer parens
+    let exprlist = []
+    let i = 0
+    while i < len(tokens)
+        let token = tokens[i]
+        if token == s:R_PAREN
+            throw "Unexpected list termination -- s:ParseList"
+        elseif token == s:L_PAREN
+            let sublistlen = s:NestedNonTerminalLen(tokens[i:])
+            call add(exprlist, vlparse#Parse(tokens[i:i+sublistlen-1]))
+            let i += sublistlen
+        elseif token == s:D_QUOTE
+            let stringlen = s:NonTerminalLen(tokens[i:])
+            call add(exprlist, vlparse#Parse(tokens[i:i+stringlen-1]))
+            let i += stringlen
+        elseif token == s:QUOTE
+            if tokens[i+1] == s:L_PAREN
+                let quotelen = s:NestedNonTerminalLen(tokens[i+1:])
+                call add(exprlist, vlparse#Parse(tokens[i:i+quotelen]))
+                let i += 1 + quotelen
+            else
+                call add(exprlist, vlparse#Parse(tokens[i:i+1]))
+                let i += 2
+            endif
+        else
+            call add(exprlist, vlparse#Parse(tokens[i:i]))
+            let i += 1
+        endif
+    endwhile
+    return exprlist
+endfunction
+
+function! s:ParsePair(tokens) abort
+    let dotpos = index(a:tokens, s:DOT)
+    if a:tokens[0] != s:L_PAREN || dotpos == -1
+        throw "Invalid pair structure -- s:ParseList"
+    endif
+    let lhs = s:ParseQuoted(a:tokens[1:dotpos-1])
+    let rhs = s:ParseQuoted(a:tokens[dotpos+1:-2])
+    return vl#Cons(lhs, rhs)
+endfunction
+
+function! s:ParseString(tokens) abort
+    if a:tokens[0] != s:D_QUOTE || a:tokens[-1] != s:D_QUOTE
+        throw "Invalid string literal: "..string(join(a:tokens))
+    endif
+    return s:StrFactory(join(a:tokens[1:-2]))
+endfunction
+
+function! s:StrFactory(str) abort
+    return ["vlobj", #{_t: g:vl_t_lstr, _chars: str2list(a:str)}]
+endfunction
+
+function! s:NestedNonTerminalLen(tokens, open=s:L_PAREN, close=s:R_PAREN) abort
+    let open_count = 0
+    for i in range(len(a:tokens))
+        let token = a:tokens[i]
+        if token == a:open
+            let open_count += 1
+        elseif token == a:close
+            let open_count -= 1
+            if open_count == 0
+                return i + 1
+            endif
+        endif
+    endfor
+    return -1
+endfunction
+
+function! s:NonTerminalLen(tokens, delim=s:D_QUOTE) abort
+    let delim_count = 0
+    for i in range(len(a:tokens))
+        let token = a:tokens[i]
+        if token == a:delim
+            let delim_count += 1
+            if delim_count == 2
+                return i + 1
+            endif
+        endif
+    endfor
+    return -1
+endfunction
+
+function! s:ParseAtom(token) abort
+    if a:token =~ s:NUMBER_R
+        return a:token - 0
+    elseif a:token =~ s:STRING_CONST_R
+        return a:token
+    elseif a:token =~? s:SYMBOL_R
+        return a:token
+    elseif a:token =~? s:BOOL_R
+        return a:token
+    elseif a:token == s:DOT
+        return a:token
+    else
+        throw "Invalid token: "..a:token
+    endif
+endfunction
+
+function! s:DeepLispList(elts) abort
+    if vlutils#IsEmptyList(a:elts)
+        return []
+    elseif len(a:elts) == 1
+        if type(a:elts[0]) == v:t_list
+            return vl#Cons(s:DeepLispList(a:elts[0]), [])
+        endif
+        return add(a:elts, [])
+    elseif type(a:elts[0]) == v:t_list
+        return vl#Cons(s:DeepLispList(a:elts[0]), s:DeepLispList(a:elts[1:]))
+    else
+        return vl#Cons(a:elts[0], s:DeepLispList(a:elts[1:]))
+    endif
+endfunction

--- a/plugin/vimlisp.vim
+++ b/plugin/vimlisp.vim
@@ -2,6 +2,7 @@ let g:vl_t_pair = "t_pair"
 let g:vl_t_sym = "t_sym"
 let g:vl_t_lstr = "t_lstr"
 let g:vl_t_void = "t_void"
+let g:vl_t_err = "t_err"
 let g:vl_bool_t = "#t"
 let g:vl_bool_f = "#f"
 let g:VL_INITIAL_ENV = vlenv#BuildInitialEnv()
@@ -37,7 +38,7 @@ function! VlEvalMultiline(lines) abort
     let lines = map(a:lines, {_, l -> s:CleanLine(l)})
     let lines = filter(lines, {_, l -> match(l, '\(^;\+\)\|^$') == -1})
     let source = join(lines)
-    let exprs = vl#SplitExprs(source)
+    let exprs = vlparse#SplitExprs(source)
     for expr in exprs
         call vl#Eval(expr)
     endfor


### PR DESCRIPTION
Registerizes most common calls in interpreter (ApplyProc, ApplyK, Analyze, etc) to try and avoid vim's function call overhead. Implements continuations as a stack. Trampolines interpreter to break recursive call chain in execution.