### PR TITLE
Env improvements

### DIFF
--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -8,7 +8,7 @@ function! tests#vl#TestVimLisp() abort
         let e = "(lambda (x y) ((lambda (z) (x y z))))"
         let e = vlparse#Parse(vlparse#Tokenize(e))
         call vltrns#ScanLambdas(e)
-        echo e
+        "echo e
     endfunction
 
     call s:TestSubRefer()

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -42,6 +42,7 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[5, '((lambda (x) ((lambda (y) y x x) x)) 5)'],
                 \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[4, '(begin 1 (+ 1 2) 4)'],
                 \[[1, 2], "'(1 . 2)"],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -1,7 +1,8 @@
 function! tests#vl#TestVimLisp() abort
     function! TestVlEval(expr) abort
-        let TEST_ENV = vl#ExtendEnv(vlenv#BuildInitialEnv(), ["x"], [3])
-        return vl#Eval(a:expr, TEST_ENV)
+        let testenv = vlenv#BuildInitialEnv()
+        let testenv[0]["x"] = 3
+        return vl#Eval(a:expr, testenv)
     endfunction
 
     function! s:TestSubRefer() abort
@@ -42,6 +43,8 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[12, '((lambda (x) x) 12)'],
+                \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[5, '((lambda (x) ((lambda (y) y x x) x)) 5)'],
                 \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[4, '(begin 1 (+ 1 2) 4)'],
@@ -61,7 +64,6 @@ function! tests#vl#TestVimLisp() abort
                 \[3, '(/ 12 4)'],
                 \[3, '(+ 1 2)'],
                 \[1, "(define x 3)"],
-                \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[1, '(define x "hello, world")'],
                 \[1, '(set! x 3)'],
                 \[3, '(begin (define x 3) x)'],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -1,8 +1,17 @@
 function! tests#vl#TestVimLisp() abort
     function! TestVlEval(expr) abort
-        let TEST_ENV = #{x: 3, __prev_frame: g:VL_INITIAL_ENV}
+        let TEST_ENV = vl#ExtendEnv(vlenv#BuildInitialEnv(), ["x"], [3])
         return vl#Eval(a:expr, TEST_ENV)
     endfunction
+
+    function! s:TestSubRefer() abort
+        let e = "(lambda (x y) ((lambda (z) (x y z))))"
+        let e = vlparse#Parse(vlparse#Tokenize(e))
+        call vltrns#ScanLambdas(e)
+        echo e
+    endfunction
+
+    call s:TestSubRefer()
 
     function! RunTests(tests) abort
         let [success, fail] = [0, 0]
@@ -48,10 +57,10 @@ function! tests#vl#TestVimLisp() abort
                 \[10, '(* 5 2)'],
                 \[3, '(/ 12 4)'],
                 \[3, '(+ 1 2)'],
-                \[0, "(define x 3)"],
+                \[1, "(define x 3)"],
                 \[12, '((lambda (x y) (+ x y)) 5 7)'],
-                \[0, '(define x "hello, world")'],
-                \[0, '(set! x 3)'],
+                \[1, '(define x "hello, world")'],
+                \[1, '(set! x 3)'],
                 \[4, '(begin 1 2 4)'],
                 \[3, '(begin (define x 3) x)'],
                 \[9, '((lambda () 5 7 9))'],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -31,7 +31,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
-                "echo "[+] "..string(expr)
+                echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr
@@ -43,10 +43,12 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[12, '((lambda (y) (define x 12) x) "y")'],
+                \[12, '((lambda (y) (set! y 12) y) 11)'],
+                \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[12, '((lambda (x) x) 12)'],
                 \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[5, '((lambda (x) ((lambda (y) y x x) x)) 5)'],
-                \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[4, '(begin 1 (+ 1 2) 4)'],
                 \[[1, 2], "'(1 . 2)"],
                 \[[1, [2, [3, []]]], "'(1 . (2 3))"],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -11,8 +11,6 @@ function! tests#vl#TestVimLisp() abort
         "echo e
     endfunction
 
-    call s:TestSubRefer()
-
     function! RunTests(tests) abort
         let [success, fail] = [0, 0]
         for [expected, actual] in a:tests
@@ -44,6 +42,10 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
+                \[4, '(begin 1 (+ 1 2) 4)'],
+                \[[1, 2], "'(1 . 2)"],
+                \[[1, [2, [3, []]]], "'(1 . (2 3))"],
                 \[[1, 2], '(cons 1 (call/cc (lambda (k) (k 2))))'],
                 \[["condition", [123, []]], '(raise 123)'],
                 \[[1, [2, []]], "'(1 . (2 . ()))"],
@@ -61,7 +63,6 @@ function! tests#vl#TestVimLisp() abort
                 \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[1, '(define x "hello, world")'],
                 \[1, '(set! x 3)'],
-                \[4, '(begin 1 2 4)'],
                 \[3, '(begin (define x 3) x)'],
                 \[9, '((lambda () 5 7 9))'],
                 \[7, '(call/cc (lambda (k) 7))'],
@@ -72,7 +73,6 @@ function! tests#vl#TestVimLisp() abort
                 \[7, '(let ((x 3) (y 4)) (+ x y))'],
                 \[7, '((lambda (x y) (+ x y)) 3 4)'],
                 \[12, '(begin (define y (lambda (x) (+ 5 7))) (y 3))'],
-                \[5, '(let ((x 3)) (let ((x 5)) x))'],
                 \[17, '(begin (define x 7) (set! x 17) x)'],
                 \[120, '(if #t 120 121)'],
                 \[121, '(if #f 120 121)'],
@@ -108,8 +108,6 @@ function! tests#vl#TestVimLisp() abort
                 \['#t', "(equal? '(1 2) '(1 2))"],
                 \['#f', "(equal? '(1 2 3) '(1 2))"],
                 \['#t', "(begin (define l '(1 2)) (eq? l l))"],
-                \[[1, 2], "'(1 . 2)"],
-                \[[1, [2, [3, []]]], "'(1 . (2 3))"],
                 \])
                 "\[5, '(let ((x 0)) (while ((< x 5)) (set! x (+ x 1))) x)'],
                 "\[0, '(let ((x 0) (y 0)) (while ((< x 5)) (set! x (+ x 1))) y)'],

--- a/autoload/tests/vl.vim
+++ b/autoload/tests/vl.vim
@@ -31,7 +31,7 @@ function! tests#vl#TestVimLisp() abort
         for [expected, expr] in a:tests
             let actual = TestVlEval(expr)
             if string(expected) == string(actual)
-                echo "[+] "..string(expr)
+                "echo "[+] "..string(expr)
                 let success += 1
             else
                 echo "[!] "..string(actual).."\t\t: "..expr
@@ -43,9 +43,9 @@ function! tests#vl#TestVimLisp() abort
     endfunction
 
     call RunEvalTests([
+                \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[12, '((lambda (y) (define x 12) x) "y")'],
                 \[12, '((lambda (y) (set! y 12) y) 11)'],
-                \[5, '(let ((x 3)) (let ((x 5)) x (+ 1 2) x))'],
                 \[12, '((lambda (x) x) 12)'],
                 \[12, '((lambda (x y) (+ x y)) 5 7)'],
                 \[5, '((lambda (x) ((lambda (y) y x x) x)) 5)'],

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -65,9 +65,13 @@ function! vl#Eval(expr, env=vlenv#BuildInitialEnv()) abort
     call s:InitRegisters()
     let tokens = vlparse#Tokenize(a:expr)
     let syntax = vlparse#Parse(tokens)
+    if type(syntax) == v:t_list
+        let syntax = vltrns#Transform(syntax)
+    endif
+    "call vltrns#ScanLambdas(syntax)
+    let s:EXPR_R = syntax
     call add(s:K_STACK, funcref("s:EndCont"))
     call s:PushHandler(funcref("vl#TopLevelHandler"))
-    let s:EXPR_R = syntax
     let s:CLOSURE_R = vl#Analyze()
     let s:ENV_R = a:env
     let Bounce = s:EvalClosure()
@@ -92,9 +96,8 @@ function! vl#TypeOf(obj) abort
 endfunction
 
 function! vl#Analyze() abort
-    let expr = vltrns#Transform(s:EXPR_R)
-    "let expr = vltrns#SubReferences(expr)
     let s:COUNTER += 1
+    let expr = s:EXPR_R
     if type(expr) == v:t_number
         return s:GenConst(expr)
     elseif type(expr) == v:t_string

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -65,6 +65,7 @@ function! vl#Eval(expr, env=vlenv#BuildInitialEnv()) abort
     call s:InitRegisters()
     let tokens = vlparse#Tokenize(a:expr)
     let syntax = vlparse#Parse(tokens)
+    let syntax = vlparse#ToLisp(syntax)
     if type(syntax) == v:t_list
         let syntax = vltrns#Transform(syntax)
     endif

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -167,14 +167,16 @@ function! s:Sequentially(closures) abort
     " expression becomes the value of the sequence.
     " We therefore need to push an 'empty' continuation
     " for each of the first n-1 expressions.
+    " Evaluating a procedure application returns a bounce,
+    " so we need to trampoline the evaluation of each closure.
     let fname = s:GenLabel("SequenceClosure")
     let closures = a:closures
     function! {fname}() closure abort
-        let K = {_ -> 0}
+        let K = {_ -> "done"}
         while vl#Cdr(closures) != []
             call add(s:K_STACK, K)
             let s:CLOSURE_R = closures[0]
-            call s:EvalClosure()
+            call s:Trampoline(s:EvalClosure())
             let closures = closures[1]
         endwhile
         let s:CLOSURE_R = closures[0]

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -65,8 +65,9 @@ function! vl#Eval(expr, env=g:VL_INITIAL_ENV) abort
     call s:InitRegisters()
     let tokens = vlparse#Tokenize(a:expr)
     let program = vlparse#Parse(tokens)
+    call vltrns#ScanLambdas(program)
+    echo program
     let program = vlparse#ToLisp(program)
-    "call vltrns#ScanLambdas(syntax)
     let s:EXPR_R = program
     call add(s:K_STACK, funcref("s:EndCont"))
     call s:PushHandler(funcref("vl#TopLevelHandler"))
@@ -325,8 +326,8 @@ function! s:ApplyEnv(env, var) abort
         endfor
         let e = e[1]
     endwhile
-    if has_key(e, var)
-        return e[var]
+    if has_key(e, a:var)
+        return e[a:var]
     endif
     throw "Unbound variable: "..a:var
 endfunction

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -61,7 +61,7 @@ function! s:EvalClosure() abort
     return s:CLOSURE_R()
 endfunction
 
-function! vl#Eval(expr, env=vlenv#BuildInitialEnv()) abort
+function! vl#Eval(expr, env=g:VL_INITIAL_ENV) abort
     call s:InitRegisters()
     let tokens = vlparse#Tokenize(a:expr)
     let program = vlparse#Parse(tokens)
@@ -314,8 +314,10 @@ function! s:DeepLispMap(proc, l) abort
 endfunction
 
 function! s:ApplyEnv(env, var) abort
+    " The top level env is a dict. Extended envs for procedure
+    " application are a list of values.
     let e = a:env
-    while e != []
+    while type(e) != v:t_dict
         for j in range(len(e[0][0]))
             if e[0][0][j] == a:var
                 return e[0][1][j]
@@ -323,6 +325,9 @@ function! s:ApplyEnv(env, var) abort
         endfor
         let e = e[1]
     endwhile
+    if has_key(e, var)
+        return e[var]
+    endif
     throw "Unbound variable: "..a:var
 endfunction
 
@@ -332,7 +337,7 @@ endfunction
 
 function! s:SetVar(env, var, val) abort
     let e = a:env
-    while e != []
+    while type(e) != v:t_dict
         for j in range(len(e[0][0]))
             if e[0][0][j] == a:var
                 let e[0][1][j] = a:val
@@ -341,12 +346,19 @@ function! s:SetVar(env, var, val) abort
         endfor
         let e = e[1]
     endwhile
+    if has_key(e, var)
+        let e[var] = val
+    endif
     throw "Unbound variable: "..a:var
 endfunction
 
 function! s:DefineVar(env, var, val) abort
-    let a:env[0][0] = add(a:env[0][0], a:var)
-    let a:env[0][1] = add(a:env[0][1], a:val)
+    if type(a:env) == v:t_list
+        let a:env[0][0] = add(a:env[0][0], a:var)
+        let a:env[0][1] = add(a:env[0][1], a:val)
+    else
+        let a:env[var] = val
+    endif
     return 1
 endfunction
 

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -64,13 +64,10 @@ endfunction
 function! vl#Eval(expr, env=vlenv#BuildInitialEnv()) abort
     call s:InitRegisters()
     let tokens = vlparse#Tokenize(a:expr)
-    let syntax = vlparse#Parse(tokens)
-    let syntax = vlparse#ToLisp(syntax)
-    if type(syntax) == v:t_list
-        let syntax = vltrns#Transform(syntax)
-    endif
+    let program = vlparse#Parse(tokens)
+    let program = vlparse#ToLisp(program)
     "call vltrns#ScanLambdas(syntax)
-    let s:EXPR_R = syntax
+    let s:EXPR_R = program
     call add(s:K_STACK, funcref("s:EndCont"))
     call s:PushHandler(funcref("vl#TopLevelHandler"))
     let s:CLOSURE_R = vl#Analyze()
@@ -98,7 +95,7 @@ endfunction
 
 function! vl#Analyze() abort
     let s:COUNTER += 1
-    let expr = s:EXPR_R
+    let expr = vltrns#Desugar(s:EXPR_R)
     if type(expr) == v:t_number
         return s:GenConst(expr)
     elseif type(expr) == v:t_string

--- a/autoload/vl.vim
+++ b/autoload/vl.vim
@@ -224,9 +224,9 @@ function! s:ApplyProc() abort
         endfunction
         return funcref(fname)
     elseif vl#Car(rator) =~? '^proc$'
-        let Body = s:ProcBody(rator)
+        let Body = vl#ProcBody(rator)
         let env = s:ProcEnv(rator)
-        let params = vlutils#FlattenList(s:ProcParams(rator))
+        let params = vlutils#FlattenList(vl#ProcParams(rator))
         let rands = vlutils#FlattenList(rands)
         let fname = s:GenLabel("ProcBounce")
         function! {fname}() closure abort
@@ -236,9 +236,9 @@ function! s:ApplyProc() abort
         endfunction
         return funcref(fname)
     elseif vl#Car(rator) =~? '^cont$'
-        let Body = s:ProcBody(rator)
+        let Body = vl#ProcBody(rator)
         let env = s:ProcEnv(rator)
-        let params = vlutils#FlattenList(s:ProcParams(rator))
+        let params = vlutils#FlattenList(vl#ProcParams(rator))
         let rands = [extend(["cont-prim"], vlutils#FlattenList(rands))]
         let fname = s:GenLabel("ContBounce")
         function! {fname}() closure abort
@@ -357,7 +357,7 @@ function! s:GenSequence(expr, sequencer) abort
     return a:sequencer(closures)
 endfunction
 
-function! s:ProcParams(proc) abort
+function! vl#ProcParams(proc) abort
     return vl#Cadr(a:proc)
 endfunction
 
@@ -365,7 +365,7 @@ function! s:ProcEnv(proc) abort
     return vl#Cadddr(a:proc)
 endfunction
 
-function! s:ProcBody(proc) abort
+function! vl#ProcBody(proc) abort
     return vl#Caddr(a:proc)
 endfunction
 

--- a/autoload/vlenv.vim
+++ b/autoload/vlenv.vim
@@ -19,6 +19,6 @@ let s:vals = [
             \]
 
 function! vlenv#BuildInitialEnv() abort
-    let env = [[s:vars, s:vals]]
+    let env = [[s:vars, s:vals], []]
     return env
 endfunction

--- a/autoload/vlenv.vim
+++ b/autoload/vlenv.vim
@@ -1,5 +1,5 @@
 function! vlenv#BuildInitialEnv() abort
-    return {
+    return [{
                 \'+': ['prim', {args -> vlbuiltins#ApplyGeneric('add2', args)}],
                 \'-': ['prim', {args -> vlbuiltins#ApplyGeneric('sub2', args)}],
                 \'*': ['prim', {args -> vlbuiltins#ApplyGeneric('mult2', args)}],
@@ -15,5 +15,5 @@ function! vlenv#BuildInitialEnv() abort
                 \'eq?': ['prim', {args -> vlbuiltins#ApplyGeneric('eq?', args)}],
                 \'#t': g:vl_bool_t,
                 \'#f': g:vl_bool_f,
-                \}
+                \}]
 endfunction

--- a/autoload/vlenv.vim
+++ b/autoload/vlenv.vim
@@ -1,24 +1,19 @@
-let s:vars = ["+", "-", "*", "/", ">", "<", ">=", "<=", "cons", "vimcall",
-            \"equal?", "eq?", "#t", "#f"]
-
-let s:vals = [
-            \['prim', {args -> vlbuiltins#ApplyGeneric('add2', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('sub2', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('mult2', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('div2', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('gt', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('lt', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('gte', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('lte', args)}],
-            \['prim', {args -> vlbuiltins#PrimitiveCons(args)}],
-            \['prim', {args -> vlbuiltins#VimCall(args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('equal?', args)}],
-            \['prim', {args -> vlbuiltins#ApplyGeneric('eq?', args)}],
-            \g:vl_bool_t,
-            \g:vl_bool_f,
-            \]
-
 function! vlenv#BuildInitialEnv() abort
-    let env = [[s:vars, s:vals], []]
-    return env
+    return {
+                \'+': ['prim', {args -> vlbuiltins#ApplyGeneric('add2', args)}],
+                \'-': ['prim', {args -> vlbuiltins#ApplyGeneric('sub2', args)}],
+                \'*': ['prim', {args -> vlbuiltins#ApplyGeneric('mult2', args)}],
+                \'/': ['prim', {args -> vlbuiltins#ApplyGeneric('div2', args)}],
+                \'>': ['prim', {args -> vlbuiltins#ApplyGeneric('gt', args)}],
+                \'<': ['prim', {args -> vlbuiltins#ApplyGeneric('lt', args)}],
+                \'>=': ['prim', {args -> vlbuiltins#ApplyGeneric('gte', args)}],
+                \'<=': ['prim', {args -> vlbuiltins#ApplyGeneric('lte', args)}],
+                \'cons': ['prim', {args -> vlbuiltins#PrimitiveCons(args)}],
+                \'vimcall': ['prim', {args -> vlbuiltins#VimCall(args)}],
+                \'equal?': ['prim',
+                \{args -> vlbuiltins#ApplyGeneric('equal?', args)}],
+                \'eq?': ['prim', {args -> vlbuiltins#ApplyGeneric('eq?', args)}],
+                \'#t': g:vl_bool_t,
+                \'#f': g:vl_bool_f,
+                \}
 endfunction

--- a/autoload/vlparse.vim
+++ b/autoload/vlparse.vim
@@ -130,8 +130,6 @@ endfunction
 function! s:ParseAtom(token) abort
     if a:token =~ s:NUMBER_R
         return a:token - 0
-    elseif a:token =~ s:STRING_CONST_R
-        return a:token
     elseif a:token =~? s:SYMBOL_R
         return a:token
     elseif a:token =~? s:BOOL_R

--- a/autoload/vlparse.vim
+++ b/autoload/vlparse.vim
@@ -163,6 +163,8 @@ function! vlparse#ToLisp(elts) abort
         return vl#Cons(vlparse#ToLisp(a:elts[0]), vlparse#ToLisp(a:elts[1:]))
     elseif a:elts[0] == "pair"
         return s:PairsToLisp(a:elts)
+    elseif a:elts[0] == "refer"
+        return a:elts
     else
         return vl#Cons(a:elts[0], vlparse#ToLisp(a:elts[1:]))
     endif

--- a/autoload/vlparse.vim
+++ b/autoload/vlparse.vim
@@ -42,7 +42,7 @@ endfunction
 
 function! s:ParseQuoted(tokens) abort
     if a:tokens[0] == s:L_PAREN && index(a:tokens, s:DOT) > 0
-        return extend(["pair"], s:ParsePair(a:tokens))
+        return extend(["#pair"], s:ParsePair(a:tokens))
     else
         return vlparse#Parse(a:tokens)
     endif
@@ -161,9 +161,9 @@ function! vlparse#ToLisp(elts) abort
         return add(a:elts, [])
     elseif type(a:elts[0]) == v:t_list
         return vl#Cons(vlparse#ToLisp(a:elts[0]), vlparse#ToLisp(a:elts[1:]))
-    elseif a:elts[0] == "pair"
+    elseif a:elts[0] == "#pair"
         return s:PairsToLisp(a:elts)
-    elseif a:elts[0] == "refer"
+    elseif a:elts[0] == "#refer"
         return a:elts
     else
         return vl#Cons(a:elts[0], vlparse#ToLisp(a:elts[1:]))
@@ -173,7 +173,7 @@ endfunction
 function! s:PairsToLisp(pair) abort
     if vlutils#IsEmptyList(a:pair)
         return a:pair
-    elseif a:pair[0] == "pair"
+    elseif a:pair[0] == "#pair"
         return [a:pair[1], s:PairsToLisp(a:pair[2])]
     else
         return vlparse#ToLisp(a:pair)

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -102,16 +102,16 @@ function! s:TransformCond(clauses) abort
     endif
 endfunction
 
-function! s:LetToLambda(expr) abort
-    let bindings = vl#Cadr(a:expr)
-    let body = vl#Cddr(a:expr)
-    let vars = vl#LispMap({x -> vl#Car(x)}, bindings)
-    let vals = vl#LispMap({x -> vl#Cadr(x)}, bindings)
-    let lambda = vl#Cons("lambda", vl#Cons(vars, body))
-    return vl#Cons(lambda, vals)
+function! vltrns#LetToLambda(expr) abort
+    let bindings = a:expr[1]
+    let body = a:expr[2:]
+    let vars = map(deepcopy(bindings), {_, x -> x[0]})
+    let vals = map(deepcopy(bindings), {_, x -> x[1]})
+    let lambda = extend(["lambda", vars], body)
+    return extend([lambda], vals)
 endfunction
 
 call s:RegisterTransformers([
-            \["let", funcref("s:LetToLambda")],
+            \["let", funcref("vltrns#LetToLambda")],
             \["cond", funcref("s:CondToIf")],
             \])

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -66,7 +66,7 @@ function! vltrns#ScanLambdas(expr, scope=[]) abort
         if type(e) == v:t_list
             call add(newexpr, vltrns#ScanLambdas(e, a:scope))
         elseif type(e) == v:t_string && e == s:LAMBDA
-            return add(newexpr, s:SubBoundVarRefs(a:expr, a:scope))
+            return extend(newexpr, s:SubBoundVarRefs(a:expr, a:scope))
         else
             call add(newexpr, e)
         endif

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -1,5 +1,7 @@
 let s:VL_TRANSFORMERS = {}
 let s:LAMBDA = "lambda"
+let s:DEFINE = "define"
+let s:SETBANG = "set!"
 
 function! s:RegisterTransformer(name, funcref) abort
     if has_key(s:VL_TRANSFORMERS, a:name)
@@ -25,36 +27,90 @@ function! vltrns#Desugar(expr) abort
     return a:expr
 endfunction
 
-function! s:SubBoundVarRefs(lambda, scope) abort
+function! s:ProcessLambda(lambda, scope) abort
     let boundvars = extend([a:lambda[1]], a:scope)
     let body = s:SubLambdaBodyRefs(a:lambda[2:], boundvars)
     return extend(["lambda", a:lambda[1]], body)
 endfunction
 
 function! s:SubLambdaBodyRefs(body, scope) abort
+    " We optimise variable lookup in lambda expressions by
+    " representing the env containing that expression's bound
+    " variables as a list of values. Every time a new lexical scope
+    " is introduced, the env is updated by pushing the newly bound
+    " values onto the front of the list of frames. We can then
+    " provide an index pair of [frame-index, value-index] in place
+    " of every variable reference inside a lambda body.
+    " See Dybvig '87, "Three Implementation Models for Scheme.
+    " Definitions inside a lambda body must be before any other 
+    " expressions. When encountered, the new var is pushed onto the
+    " front of the list of vars for the current lexical scope, so
+    " the index of the value can be computed. At runtime, the new
+    " value is pushed onto the front of the current frame when
+    " the define expression is executed.
     let newbody = []
-    for expr in a:body
+    let scope = a:scope
+    let i = 0
+    while i < len(a:body) && type(a:body[i]) == v:t_list
+        if type(a:body[i][0]) == v:t_string && a:body[i][0] == s:DEFINE
+            " Add the var to be defined to the front of the current frame.
+            " Any binding over a function parameter will then be shadowed
+            " by the new definition.
+            let scope[0] = extend(a:body[i][1:1], scope[0])
+            call add(newbody, s:NestedDefineAddVar(a:body[i], scope))
+            let i += 1
+        else
+            break
+        endif
+    endwhile
+    for expr in a:body[i:]
         if type(expr) == v:t_list
-            if type(expr[0]) == v:t_string && expr[0] == s:LAMBDA
-                call add(newbody, s:SubBoundVarRefs(expr, a:scope))
+            if type(expr[0]) == v:t_string
+                if expr[0] == s:LAMBDA
+                    call add(newbody, s:ProcessLambda(expr, scope))
+                elseif expr[0] == s:DEFINE
+                    throw "define in invalid body position"
+                elseif expr[0] == s:SETBANG
+                    call add(newbody, s:NestedDefineSetVar(expr, scope))
+                endif
             else
-                call add(newbody, s:SubLambdaBodyRefs(expr, a:scope))
+                call add(newbody, s:SubLambdaBodyRefs(expr, scope))
             endif
         elseif type(expr) == v:t_string
-            let next = expr
-            for frame in range(len(a:scope))
-                let pos = index(a:scope[frame], expr)
-                if pos > -1
-                    let next = ["refer", [frame, pos]]
-                    break
-                endif
-            endfor
-            call add(newbody, next)
+            call add(newbody, s:GetLambdaEnvRef(expr, scope))
         else
             call add(newbody, expr)
         endif
     endfor
     return newbody
+endfunction
+
+function! s:GetLambdaEnvRef(expr, scope) abort
+    for frame in range(len(a:scope))
+        let pos = index(a:scope[frame], a:expr)
+        if pos > -1
+            return ["#refer", [frame, pos]]
+        endif
+    endfor
+    return a:expr
+endfunction
+
+function! s:NestedDefineAddVar(expr, scope) abort
+    let val = vltrns#ScanLambdas(a:expr[2], a:scope)
+    return ["#defvar", a:expr[1], val]
+endfunction
+
+function! s:NestedDefineSetVar(expr, scope) abort
+    let val = vltrns#ScanLambdas(a:expr[2], a:scope)
+    let envref = s:GetLambdaEnvRef(a:expr[1], a:scope)
+    if type(envref) == v:t_string
+        " var not found in lambda scope. Return a set!,
+        " which will try to mutate a variable in the top
+        " level environment.
+        return add(a:expr[:1], val)
+    else
+        return ["#setvar", envref, val]
+    endif
 endfunction
 
 function! vltrns#ScanLambdas(expr, scope=[]) abort
@@ -66,7 +122,7 @@ function! vltrns#ScanLambdas(expr, scope=[]) abort
         if type(e) == v:t_list
             call add(newexpr, vltrns#ScanLambdas(e, a:scope))
         elseif type(e) == v:t_string && e == s:LAMBDA
-            return extend(newexpr, s:SubBoundVarRefs(a:expr, a:scope))
+            return extend(newexpr, s:ProcessLambda(a:expr, a:scope))
         else
             call add(newexpr, e)
         endif

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -41,7 +41,7 @@ function! s:SubLambdaBodyRefs(body, scope) abort
     " values onto the front of the list of frames. We can then
     " provide an index pair of [frame-index, value-index] in place
     " of every variable reference inside a lambda body.
-    " See Dybvig '87, "Three Implementation Models for Scheme.
+    " See Dybvig '87, 'Three Implementation Models for Scheme'.
     " Definitions inside a lambda body must be before any other 
     " expressions. When encountered, the new var is pushed onto the
     " front of the list of vars for the current lexical scope, so
@@ -72,6 +72,8 @@ function! s:SubLambdaBodyRefs(body, scope) abort
                     throw "define in invalid body position"
                 elseif expr[0] == s:SETBANG
                     call add(newbody, s:NestedDefineSetVar(expr, scope))
+                else  " procedure application
+                    call add(newbody, s:SubLambdaBodyRefs(expr, scope))
                 endif
             else
                 call add(newbody, s:SubLambdaBodyRefs(expr, scope))
@@ -109,7 +111,7 @@ function! s:NestedDefineSetVar(expr, scope) abort
         " level environment.
         return add(a:expr[:1], val)
     else
-        return ["#setvar", envref, val]
+        return ["#setbang", envref, val]
     endif
 endfunction
 

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -112,6 +112,5 @@ function! vltrns#LetToLambda(expr) abort
 endfunction
 
 call s:RegisterTransformers([
-            \["let", funcref("vltrns#LetToLambda")],
             \["cond", funcref("s:CondToIf")],
             \])

--- a/autoload/vltrns.vim
+++ b/autoload/vltrns.vim
@@ -13,22 +13,15 @@ function! s:RegisterTransformers(transformers) abort
     endfor
 endfunction
 
-function! vltrns#Transform(expr) abort
+function! vltrns#Desugar(expr) abort
     if vlutils#IsEmptyList(a:expr) || type(a:expr) != v:t_list
         return a:expr
-    elseif type(a:expr[0]) == v:t_list
-        return [vltrns#Transform(a:expr[0]), vltrns#Transform(a:expr[1])]
-    elseif type(a:expr[0]) != v:t_string || a:expr[0] == "vlobj"
-        return [a:expr[0], vltrns#Transform(a:expr[1])]
-    elseif has_key(s:VL_TRANSFORMERS, a:expr[0])
-        let transformed = get(s:VL_TRANSFORMERS, a:expr[0])(a:expr)
-        if type(transformed) != v:t_list
-            return transformed
+    elseif type(a:expr[0]) == v:t_string
+        if has_key(s:VL_TRANSFORMERS, a:expr[0])
+            return get(s:VL_TRANSFORMERS, a:expr[0])(a:expr)
         endif
-        return [vltrns#Transform(transformed[0]), vltrns#Transform(transformed[1])]
-    else
-        return [a:expr[0], vltrns#Transform(a:expr[1])]
     endif
+    return a:expr
 endfunction
 
 function! s:SubRefer(expr, bound=[])

--- a/autoload/vlutils.vim
+++ b/autoload/vlutils.vim
@@ -1,3 +1,21 @@
+let s:NODE_ELT = 0
+let s:NODE_L = 1
+let s:NODE_R = 2
+
+function! vlutils#LispIndexOf(elt, l) abort
+    let index = 0
+    let found = -1
+    let list = a:l
+    while !vlutils#IsEmptyList(list)
+        if a:elt == list[0]
+            return index
+        endif
+        let list = list[1]
+        let index += 1
+    endwhile
+    return found
+endfunction
+
 function! vlutils#IsEmptyList(obj) abort
     return type(a:obj) == v:t_list && a:obj == []
 endfunction

--- a/autoload/vlutils.vim
+++ b/autoload/vlutils.vim
@@ -54,3 +54,65 @@ function! vlutils#TimeExecution(func) abort
     let end = system("date +%s.%N")
     return str2float(end) - str2float(start)
 endfunction
+
+function! s:MakeSetNode(x) abort
+    " [str, left (<), right (>)]
+    return [a:x, "", ""]
+endfunction
+
+function! vlutils#MakeStrSet() abort
+    " B-Tree representation of set
+    return s:MakeSetNode("")
+endfunction
+
+function! vlutils#StrSetMember(root, x) abort
+    let n = a:root
+    while 1
+        if n[s:NODE_ELT] == ""
+            return 0
+        elseif a:x == n[s:NODE_ELT]
+            return 1
+        elseif a:x > n[s:NODE_ELT]
+            let n = n[s:NODE_R]
+        else
+            let n = n[s:NODE_L]
+        endif
+    endwhile
+endfunction
+
+function! vlutils#StrSetInsert(root, x) abort
+    let node = a:root
+    if node[s:NODE_ELT] == ""
+        let node[s:NODE_ELT] = a:x
+        return 1
+    endif
+    while 1
+        if a:x == node[s:NODE_ELT]
+            return 0
+        elseif a:x > node[s:NODE_ELT]
+            if type(node[s:NODE_R]) == v:t_list
+                let node = node[s:NODE_R]
+            else
+                let node[s:NODE_R] = s:MakeSetNode(a:x)
+                return 1
+            endif
+        else
+            if type(node[s:NODE_L]) == v:t_list
+                let node = node[s:NODE_L]
+            else
+                let node[s:NODE_L] = s:MakeSetNode(a:x)
+                return 1
+            endif
+        endif
+    endwhile
+endfunction
+
+function! vlutils#StrSetForEach(proc, node) abort
+    if a:node[s:NODE_ELT] == ""
+        return
+    else
+        call a:proc(a:node)
+        call vlutils#StrSetForEach(a:proc, a:node[s:NODE_L])
+        call vlutils#StrSetForEach(a:proc, a:node[s:NODE_R])
+    endif
+endfunction

--- a/plugin/init.vl
+++ b/plugin/init.vl
@@ -1,2 +1,2 @@
-(define current-handler (lambda () _current-handler))
-(define throw (lambda (exc) ((current-handler) exc)))
+;(define current-handler (lambda () _current-handler))
+;(define throw (lambda (exc) ((current-handler) exc)))


### PR DESCRIPTION
Makes a number of changes to facilitate improved environment access and manipulation. The changes improve the average and worst case performance (admittedly with crude benchmarking).

I implemented a method described by [Dybvig, 87](https://cs.indiana.edu/~dyb/papers/3imp.pdf) and also in [Essentials of Programming Languages](http://eopl3.com/), in which the environment for a lambda expression is represented as a list of the values of the variables bound in that expression. At compile time, after replacing all let expressions with immediately applied lambdas, we scan out any variable references in the body of the lambda and replace it with an explicit reference to the location of the variable's value in the env.

The expression:
```scheme
((lambda (x y) ((lambda (z) (x y z)) 3)) f 2)
```

will be translated to
```scheme
((lambda (x y) ((lambda (z) ((#refer . (1 . 0)) (#refer . (1 . 1)) (#refer . (0 . 0))) 3)) f 2)
```

The pairs inside the `#refer` expressions are an index into a lexical scope, and a variable index respectively. At the time of evaluating the body of the outermost lambda above, the environment will be:

```
[[f, 2], { ... top-level env}]
```

and when evaluating the innermost body;

```
[[3], [f, 2], { ... top-level env}]
```

To determine the position of a variable in the environment, the interpreter maintains a representation of the environment that mirrors the environment at runtime, with variable names in place of values. This is a simple matter of adding a lambda's parameter list to the front of the current list of frames.

`define` expressions in the body of a lambda are handled at compile time by pushing the new variable's name to the front of the current frame in the interpreter's representation of the runtime environment. This enables us to compute the variable's position if it is subsequently encountered in the body of the lambda.

`set!` expressions are handled similarly - find the location of the variable in the environment, replace the expression with a special form if the variable occurs bound, or leave it as is if not, in which case the interpreter will try to apply it to the top-level environment at runtime.

There is some conditional logic for handling the top-level environment differently from bound variables in lambda expressions.